### PR TITLE
fix: /auth/reissue에 refreshToken 갱신 로직 추가

### DIFF
--- a/src/controllers/hostController.js
+++ b/src/controllers/hostController.js
@@ -1,5 +1,6 @@
 const encrypt = require('../modules/cryto');
 const hostModel = require('../models/host');
+const authModel = require('../models/auth');
 const jwt = require('../modules/jwt');
 const util = require('../modules/util');
 const responseMessage = require('../modules/responseMessage');
@@ -76,7 +77,7 @@ exports.singIn = async (req, res) => {
 
     if (result[0].host_password === hashed) {
       const { accessToken, refreshToken } = await jwt.sign(result[0]);
-      await hostModel.putRefreshToken(result[0].host_idx, refreshToken);
+      await authModel.putRefreshToken(result[0].host_idx, refreshToken);
       return res
         .status(statusCode.OK)
         .set({ token: accessToken, refreshToken: refreshToken })

--- a/src/models/auth.js
+++ b/src/models/auth.js
@@ -1,0 +1,29 @@
+const pool = require('../modules/pool');
+const table = 'HOST_TB';
+
+/**
+ * reIssue : refreshToken 조회
+ */
+exports.getRefreshToken = async (idx) => {
+  const query = `SELECT host_refresh_token FROM ${table} where host_idx=${idx}`;
+
+  try {
+    return await pool.queryParam(query);
+  } catch (err) {
+    console.log('getRefreshToken error: ', err.message);
+    throw err;
+  }
+};
+
+/**
+ * 리프레시 토큰 저장
+ */
+exports.putRefreshToken = async (idx, refreshToken) => {
+  const query = `UPDATE ${table} SET host_refresh_token='${refreshToken}' where host_idx=${idx};`;
+  try {
+    return await pool.queryParam(query);
+  } catch (err) {
+    console.log('putRefreshToken error: ', err.message);
+    throw err;
+  }
+};

--- a/src/models/host.js
+++ b/src/models/host.js
@@ -36,17 +36,6 @@ exports.checkEmail = async (email) => {
   }
 };
 
-// 리프레시 토큰 저장
-exports.putRefreshToken = async (idx, refreshToken) => {
-  const query = `UPDATE ${table} SET host_refresh_token = '${refreshToken}' where host_idx=${idx};`;
-  try {
-    return await pool.queryParam(query);
-  } catch (err) {
-    console.log('putRefreshToken error: ', err.message);
-    throw err;
-  }
-};
-
 // idx로 호스트 정보 조회
 exports.getUserInfo = async (idx) => {
   const columns =

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const authController = require('../../controller/authController');
+const authController = require('../controllers/authController');
 
 // 토큰 재발행
 router.get('/reissue', authController.reIssue);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -3,6 +3,7 @@ var router = express.Router();
 const support = require('./support');
 const story = require('./story');
 const host = require('./host');
+const auth = require('./auth');
 
 /* GET home page. */
 router.get('/', function (req, res, next) {
@@ -12,5 +13,6 @@ router.get('/', function (req, res, next) {
 router.use('/story', story);
 router.use('/support', support);
 router.use('/host', host);
+router.use('/auth', auth);
 
 module.exports = router;


### PR DESCRIPTION
+ hostModel의 putRefreshToken 로직 authModel로 이동

제 의견입니다만,, 
token 관련을 /auth에서 처리하려고 했는데
생각해보니 로그인, 회원가입도 /auth에 있는게 맞지 않나?...라는 생각이 드는데
두개 API를 /host에서 /auth로 이동하는 걸 어떻게 생각하시는지?...